### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 wstunnel 
 ========
-[![Build Status](https://travis-ci.org/ffalcinelli/wstunnel.png)](https://travis-ci.org/ffalcinelli/wstunnel)[![Coverage Status](https://coveralls.io/repos/ffalcinelli/wstunnel/badge.png)](https://coveralls.io/r/ffalcinelli/wstunnel)[![PyPI Version](https://pypip.in/v/wstunnel/badge.png)](https://crate.io/packages/wstunnel)	
+[![Build Status](https://travis-ci.org/ffalcinelli/wstunnel.png)](https://travis-ci.org/ffalcinelli/wstunnel)[![Coverage Status](https://coveralls.io/repos/ffalcinelli/wstunnel/badge.png)](https://coveralls.io/r/ffalcinelli/wstunnel)[![PyPI Version](https://img.shields.io/pypi/v/wstunnel.svg)](https://crate.io/packages/wstunnel)	
 
 A WebSocket tunneling software written in python on top of [tornado](http://www.tornadoweb.org/) web framework for asynchronous I/O.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20wstunnel))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `wstunnel`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.